### PR TITLE
Updated schema so now passes tests!

### DIFF
--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -88,6 +88,8 @@ TopicObject:
             - icon:text
             - icon:bgColor
             - banned_until_readable
+        private:
+          type: string
         teaser:
           type: object
           properties:
@@ -219,6 +221,8 @@ TopicObjectSlim:
           type: number
         deleted:
           type: number
+        private:
+          type: string
         deleterUid:
           type: number
         titleRaw:

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -13,7 +13,7 @@ module.exports = function () {
 	const multipart = require('connect-multiparty');
 	const multipartMiddleware = multipart();
 
-	setupApiRoute(router, 'post', '/', [middleware.checkRequired.bind(null, ['cid', 'title', 'content', 'isprivate'])], controllers.write.topics.create);
+	setupApiRoute(router, 'post', '/', [middleware.checkRequired.bind(null, ['cid', 'title', 'content'])], controllers.write.topics.create);
 	setupApiRoute(router, 'get', '/:tid', [], controllers.write.topics.get);
 	setupApiRoute(router, 'post', '/:tid', [middleware.checkRequired.bind(null, ['content']), middleware.assert.topic], controllers.write.topics.reply);
 	setupApiRoute(router, 'delete', '/:tid', [...middlewares], controllers.write.topics.purge);


### PR DESCRIPTION
Updated schema of topic objects in order to pass the tests that check if responses match the schemas. Also changed the requirements of the api route so that "isprivate" is no longer required. This allows the previous existing tests to pass and since I have a default value for "private", it won't affect the functionality of my code. This resolves #19 